### PR TITLE
Filter out Down and OutOfService instances

### DIFF
--- a/eureka-client.cabal
+++ b/eureka-client.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                eureka-client
-version:             0.5.0.2
+version:             0.5.1.0
 synopsis:            a Eureka client library for Haskell
 -- description:
 license:             Apache-2.0

--- a/src/Network/Eureka/Types.hs
+++ b/src/Network/Eureka/Types.hs
@@ -291,7 +291,7 @@ instance Default InstanceConfig where
     }
 
 data InstanceStatus = Up | Down | Starting | OutOfService | Unknown
-                    deriving Show
+                    deriving (Show, Eq)
 
 toNetworkName :: InstanceStatus -> String
 toNetworkName Up = "UP"


### PR DESCRIPTION
At the moment, the Eureka Client does not filter out DOWN and
OUT_OF_SERVICE instances when getting apps by name. This can lead to an
service calling a DOWN or OUT_OF_SERVICE service when it shouldn't.

NOTE: the old name `lookupByAppName` was kept for the new "no_down" function while a new function `lookupByAppNameAll` was made that replicated the behavior of the old `lookupByAppName`. This assumes that the old behavior was a bug and is now being fixed. 