### PR TITLE
Catch and convert TERM signals into INT

### DIFF
--- a/eureka-client.cabal
+++ b/eureka-client.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                eureka-client
-version:             0.5.1.0
+version:             0.5.2.0
 synopsis:            a Eureka client library for Haskell
 -- description:
 license:             Apache-2.0
@@ -40,6 +40,7 @@ library
     stm,
     text,
     time,
+    unix >= 2.5 && <2.8,
     vector
   hs-source-dirs:      src
   default-language:    Haskell2010
@@ -61,6 +62,7 @@ executable test
     stm,
     text,
     time,
+    unix >= 2.7 && <2.8,
     vector
   hs-source-dirs:     src
   default-language:   Haskell2010

--- a/eureka-client.cabal
+++ b/eureka-client.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                eureka-client
-version:             0.5.2.0
+version:             0.5.1.1
 synopsis:            a Eureka client library for Haskell
 -- description:
 license:             Apache-2.0

--- a/src/Network/Eureka.hs
+++ b/src/Network/Eureka.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Network.Eureka (
+  withEurekaH,
   withEureka,
   EurekaConfig(..),
   InstanceConfig(..),
@@ -36,7 +37,7 @@ import           Network.Eureka.Types      (AmazonDataCenterInfo (..),
 import           Network.HTTP.Client       (Manager, responseBody, parseUrl, httpLbs)
 
 import Network.Eureka.Application (lookupByAppName, lookupAllApplications)
-import Network.Eureka.Connection (withEureka, setStatus, EurekaConnection)
+import Network.Eureka.Connection (withEureka, withEurekaH, setStatus, EurekaConnection)
 import Network.Eureka.Metadata (addMetadata, lookupMetadata)
 
 -- | Interrogate the magical URL http://169.254.169.254/latest/meta-data to


### PR DESCRIPTION
By default, ghc does not install handlers for any of the signals except
for INT and PIPE: 

http://stackoverflow.com/a/18431705
https://ghc.haskell.org/trac/ghc/ticket/6113#comment:1

This is the reason `bracket` doesn't release the resource on SIG_TERM.
This PR adds a handler for SIG_TERM that simply raises a SIG_INT.