### PR TITLE
Add a hostname field to the InstanceConfig object

### DIFF
--- a/eureka-client.cabal
+++ b/eureka-client.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                eureka-client
-version:             0.5.1.1
+version:             0.6.0.0
 synopsis:            a Eureka client library for Haskell
 -- description:
 license:             Apache-2.0

--- a/src/Network/Eureka/Connection.hs
+++ b/src/Network/Eureka/Connection.hs
@@ -76,12 +76,13 @@ connectEureka manager
   iConfig@InstanceConfig{
       instanceLeaseRenewalInterval=heartbeatInterval
       , instanceEnabledOnInit
+      , instanceHostName
       } dataCenterInfo = mfix $ \econn -> do
   heartbeatThreadId <- forkIO $ heartbeatThread econn ()
   instanceInfoThreadId <- forkIO $ instanceInfoThread econn def
   statusVar <- atomically $ newTVar (if instanceEnabledOnInit then Up else Starting)
 
-  hostname <- getHostName
+  hostname <- maybe getHostName return instanceHostName
   hostResolved <- getAddrInfo (Just myHints) (Just hostname) Nothing
   (Just hostIpv4, _) <- getNameInfo [NI_NUMERICHOST] True False
                         . addrAddress . head $ hostResolved

--- a/src/Network/Eureka/Types.hs
+++ b/src/Network/Eureka/Types.hs
@@ -107,6 +107,9 @@ data InstanceConfig = InstanceConfig {
       -- ^ A possible override for the "virtual hostname" or VIP that you should
       -- use to access this instance securely. This hostname should have the
       -- form "hostname:port". If Nothing, just use hostname + secure port.
+    , instanceHostName :: Maybe HostName
+      -- ^ The machine's hostname.
+      -- If Nothing, use getHostName from Network.BSD.
     , instanceStatusPageUrl :: Maybe String
       -- ^ URL to use to access this instance's status page.
     , instanceHomePageUrl :: String
@@ -284,6 +287,7 @@ instance Default InstanceConfig where
     , instanceSecurePort = 443
     , instanceVirtualHostname = Nothing
     , instanceSecureVirtualHostname = Nothing
+    , instanceHostName = Nothing
     , instanceStatusPageUrl = Nothing
     , instanceHomePageUrl = ""
     , instanceMetadata = Map.empty


### PR DESCRIPTION
At work, we run mixed Docker/non-Docker microservices that need to talk to one another. From within a Docker container, the hostname retrieved is the Docker container ID, which is not helpful when you want to talk to the container from outside. For this reason, we'd like to be able to sometimes specify a hostname to use. The default behavior of `getHostName` is probably OK for most people, though, so let's make it be configurable.